### PR TITLE
Api surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Highlights by category:
 - Classes & CSS: `addClass/removeClass/toggleClass/hasClass`, `css`, `cssVar/cssVars`, `computed`
 - Visibility & layout: `show/hide/toggle/isVisible`, `width/height/inner*/outer*`, `offset/position/offsetParent`, `scrollTop/scrollLeft`, `rect`
 - Events: `on/once/off/trigger`, shortcuts like `click`, `focus`, `blur`, `hover`, pointer/touch helpers
+  - `.trigger(type[, init])` accepts `EventInit | CustomEventInit` and defaults to `{ bubbles: true }`; non‑object becomes `{ detail }`.
 - Forms: `serialize`, `toFormData`, `setForm`, `reset`
 
 ## Templates

--- a/README.md
+++ b/README.md
@@ -124,10 +124,12 @@ dom(".items")
 Highlights by category:
 - Traversal: `find`, `children`, `parent`, `parents`, `siblings`, `closest`, `first`, `last`, `eq`, `get`, `slice`, `map`, `index`
 - Content & attrs: `text`, `html`, `append`, `prepend`, `before`, `after`, `replaceWith`, `wrap*`, `empty`, `clone`, `attr/attrs`, `prop`, `val`, `data`
+  - `.dataset(map)` to set multiple `data-*` attrs; `.aria(name[, value])` and `.aria(map)` helpers
 - Classes & CSS: `addClass/removeClass/toggleClass/hasClass`, `css`, `cssVar/cssVars`, `computed`
 - Visibility & layout: `show/hide/toggle/isVisible`, `width/height/inner*/outer*`, `offset/position/offsetParent`, `scrollTop/scrollLeft`, `rect`
 - Events: `on/once/off/trigger`, shortcuts like `click`, `focus`, `blur`, `hover`, pointer/touch helpers
   - `.trigger(type[, init])` accepts `EventInit | CustomEventInit` and defaults to `{ bubbles: true }`; non‑object becomes `{ detail }`.
+  - Delegation supported at collection and top‑level: `on(el|document|window, 'click', 'a.item', handler)`.
 - Forms: `serialize`, `toFormData`, `setForm`, `reset`
 
 ## Templates

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -80,7 +80,9 @@ Visibility & layout:
 - Rect: `.rect()` (getBoundingClientRect snapshot)
 
 Events (collection):
-- `.on(types[, selector], handler, [options])`, `.once(...)`, `.off([types[, selector[, handler]]])`, `.trigger(type, detail?)`
+- `.on(types[, selector], handler, [options])`, `.once(...)`, `.off([types[, selector[, handler]]])`, `.trigger(type[, init])`
+  - `init` accepts `EventInit | CustomEventInit | any` (non‑object becomes `{ detail }`)
+  - Defaults to `{ bubbles: true }` if unspecified
 - Shortcuts: `.click([handler])`, `.focus()`, `.blur()`, `.hover(enter, leave)`
 - Pointer/touch: `.pointerdown/move/up/enter/leave/cancel()`, `.touchstart/move/end/cancel()`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -37,7 +37,9 @@ Note: “Import‑safe on server” means modules do not access `window`/`docume
 
 - Call `dom(selector, [context])` → `DOMCollection`
 - Utilities: `dom.fromHTML(html)`, `dom.create(tag, attrs?, children?)`
-- Events: `dom.on/once/off(target, types, handler, options)`, `dom.ready(fn)`
+- Events: `dom.on/once/off(target, types[, selector], handler, options)`, `dom.ready(fn)`
+  - Supports direct and delegated forms for `Element`, `Document`, and `Window`
+  - Multiple event types and namespaces (e.g. `"click resize.ns"`) supported
 - Plugins: `dom.use(plugin)`
 - Class: `dom.DOMCollection`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -65,6 +65,8 @@ Content & structure:
 Attributes, properties, values:
 - `.attr(name[, value])`, `.attrs(map)`
 - `.prop(name[, value])`, `.val([value])`, `.data(name[, value])`
+- `.dataset([map])` → get all dataset of first element or set multiple `data-*` attrs
+- `.aria(name[, value])` or `.aria(map)` → convenience for `aria-*` attributes
 
 Classes & styles:
 - `.addClass(...names)`, `.removeClass(...names)`, `.toggleClass(names[, force])`, `.hasClass(name)`, `.replaceClass(oldClasses, newClasses)`
@@ -83,6 +85,10 @@ Events (collection):
 - `.on(types[, selector], handler, [options])`, `.once(...)`, `.off([types[, selector[, handler]]])`, `.trigger(type[, init])`
   - `init` accepts `EventInit | CustomEventInit | any` (non‑object becomes `{ detail }`)
   - Defaults to `{ bubbles: true }` if unspecified
+
+Iteration helpers:
+- `.each(fn)` → iterate elements
+- `.beforeEach(fn)`, `.afterEach(fn)` → aliases to `.each(fn)` for chain readability
 - Shortcuts: `.click([handler])`, `.focus()`, `.blur()`, `.hover(enter, leave)`
 - Pointer/touch: `.pointerdown/move/up/enter/leave/cancel()`, `.touchstart/move/end/cancel()`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dmitrijkiltau/dom.js",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^26.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.4",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dmitrijkiltau/dom.js",
-      "version": "1.6.4",
+      "version": "1.6.6",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^26.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",
@@ -87,7 +87,7 @@
     "build:core": "tsup src/core.ts --format esm,cjs --dts --minify",
     "analyze": "node scripts/analyze-bundles.mjs",
     "dev": "tsup src/index.ts --format esm --dts --watch",
-    "test": "node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/dom-manipulation.test.mjs && node ./tests/events-delegated.test.mjs",
+    "test": "node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/dom-manipulation.test.mjs && node ./tests/events-delegated.test.mjs && node ./tests/trigger-init.test.mjs",
     "test:types": "tsc -p tests/tsconfig.types.json",
     "test:core": "node ./tests/sanity.mjs",
     "test:modular": "node ./tests/modular.mjs",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "ARCHITECTURE.md",
+    "REFERENCE.md"
   ],
   "scripts": {
     "build": "tsup src/index.ts src/core.ts src/http.ts src/template.ts src/forms.ts src/motion.ts src/utils.ts src/observers.ts src/scroll.ts src/server.ts --format esm,cjs --dts --minify --splitting false --clean",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",
@@ -87,7 +87,7 @@
     "build:core": "tsup src/core.ts --format esm,cjs --dts --minify",
     "analyze": "node scripts/analyze-bundles.mjs",
     "dev": "tsup src/index.ts --format esm --dts --watch",
-    "test": "node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/dom-manipulation.test.mjs && node ./tests/events-delegated.test.mjs && node ./tests/trigger-init.test.mjs",
+    "test": "node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/dom-manipulation.test.mjs && node ./tests/events-delegated.test.mjs && node ./tests/trigger-init.test.mjs && node ./tests/qol-helpers.test.mjs",
     "test:types": "tsc -p tests/tsconfig.types.json",
     "test:core": "node ./tests/sanity.mjs",
     "test:modular": "node ./tests/modular.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",
@@ -87,7 +87,7 @@
     "build:core": "tsup src/core.ts --format esm,cjs --dts --minify",
     "analyze": "node scripts/analyze-bundles.mjs",
     "dev": "tsup src/index.ts --format esm --dts --watch",
-    "test": "node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/dom-manipulation.test.mjs",
+    "test": "node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/dom-manipulation.test.mjs && node ./tests/events-delegated.test.mjs",
     "test:types": "tsc -p tests/tsconfig.types.json",
     "test:core": "node ./tests/sanity.mjs",
     "test:modular": "node ./tests/modular.mjs",

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -959,6 +959,55 @@ export class DOMCollection<T extends Element = Element> {
     return this.attr(key, value as any);
   }
 
+  // Dataset helpers
+  dataset(): Record<string, string>;
+  dataset(map: Record<string, string | number | null | undefined>): this;
+  dataset(map?: Record<string, string | number | null | undefined>): any {
+    if (map === undefined) {
+      const first = this.elements[0] as unknown as HTMLElement | undefined;
+      const out: Record<string, string> = {};
+      if (!first) return out;
+      const ds = (first as any).dataset as DOMStringMap;
+      for (const k in ds) { if (Object.prototype.hasOwnProperty.call(ds, k)) out[k] = ds[k] as string; }
+      return out;
+    }
+    return this.each(el => {
+      const h = el as unknown as HTMLElement;
+      for (const [k, v] of Object.entries(map)) {
+        const attr = k.startsWith('data-') ? k : `data-${camelToKebab(k)}`;
+        if (v == null) h.removeAttribute(attr);
+        else h.setAttribute(attr, String(v));
+      }
+    });
+  }
+
+  // ARIA attribute helper
+  aria(name: string): string | null;
+  aria(name: string, value: string | number | boolean | null | undefined): this;
+  aria(map: Record<string, string | number | boolean | null | undefined>): this;
+  aria(nameOrMap: any, value?: any): any {
+    if (typeof nameOrMap === 'string') {
+      const attr = nameOrMap.startsWith('aria-') ? nameOrMap : `aria-${nameOrMap}`;
+      if (value === undefined) return this.attr(attr);
+      const v = typeof value === 'boolean' ? (value ? 'true' : 'false') : value;
+      return this.attr(attr, v == null ? null : String(v));
+    }
+    const map = nameOrMap as Record<string, any>;
+    return this.each(el => {
+      const h = el as unknown as HTMLElement;
+      for (const [k, v] of Object.entries(map)) {
+        const attr = k.startsWith('aria-') ? k : `aria-${k}`;
+        const val = typeof v === 'boolean' ? (v ? 'true' : 'false') : v;
+        if (val == null) h.removeAttribute(attr);
+        else h.setAttribute(attr, String(val));
+      }
+    });
+  }
+
+  // Iterator helpers for symmetry/readability
+  beforeEach(fn: (el: T, idx: number) => void): this { return this.each(fn); }
+  afterEach(fn: (el: T, idx: number) => void): this { return this.each(fn); }
+
   // Form serialization
   serialize(): Record<string, any> {
     if (this.elements.length === 0) return {};

--- a/src/core-api.ts
+++ b/src/core-api.ts
@@ -1,0 +1,92 @@
+import { MaybeArray, Selector, EventTargetish } from './types';
+import { isString, isElement, isDocument, isWindow, hasDOM } from './utils';
+import { DOMCollection } from './collection';
+import { onDirect, removeManaged, removeAllManaged, ready as domReady } from './events';
+
+// ——— Core selector ———
+export function dom<T extends Element = Element>(input?: Selector<T>, context?: Element | Document | DOMCollection): DOMCollection<T> {
+  if (!input) return new DOMCollection([]);
+  if (isString(input)) {
+    const s = input.trim();
+    if (s.startsWith('<') && s.endsWith('>')) return fromHTML(s) as unknown as DOMCollection<T>;
+    if (!context) return hasDOM() ? new DOMCollection(document.querySelectorAll(s) as any) : new DOMCollection([] as any);
+    if (context instanceof DOMCollection) {
+      const found: Element[] = [] as any;
+      for (const el of context.elements) found.push(...(hasDOM() ? (el.querySelectorAll(s) as any) : []));
+      return new DOMCollection(found) as unknown as DOMCollection<T>;
+    }
+    if (context instanceof Element) return hasDOM() ? new DOMCollection(context.querySelectorAll(s) as any) as unknown as DOMCollection<T> : new DOMCollection([] as any);
+    return hasDOM() ? new DOMCollection((context as Document).querySelectorAll(s) as any) as unknown as DOMCollection<T> : new DOMCollection([] as any);
+  }
+  if (isElement(input)) return new DOMCollection([input as T]);
+  if (input instanceof NodeList || Array.isArray(input)) return new DOMCollection(input as any);
+  if (isDocument(input)) return new DOMCollection([input.documentElement as any]);
+  if (isWindow(input)) return new DOMCollection([input.document.documentElement as any]);
+  return new DOMCollection([]) as DOMCollection<T>;
+}
+
+// ——— HTML string to elements ———
+export function fromHTML(html: string): DOMCollection {
+  if (!hasDOM()) return new DOMCollection([]);
+  const tpl = document.createElement('template');
+  tpl.innerHTML = html.trim();
+  return new DOMCollection(Array.from(tpl.content.children) as any);
+}
+
+// ——— Element creation ———
+export function create(tag: string, attrs?: Record<string, any> | null, children?: MaybeArray<string | Node | DOMCollection>): Element {
+  if (!hasDOM()) throw new Error('create(tag) requires a DOM environment');
+  const el = document.createElement(tag);
+  if (attrs) for (const [k, v] of Object.entries(attrs)) setAttr(el, k, v);
+  if (children) appendChildren(el, children);
+  return el;
+}
+
+// ——— Event helpers ———
+export function on<K extends keyof GlobalEventHandlersEventMap>(target: Element | DOMCollection, types: K, handler: (ev: GlobalEventHandlersEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function on<K extends keyof DocumentEventMap>(target: Document, types: K, handler: (ev: DocumentEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function on<K extends keyof WindowEventMap>(target: Window, types: K, handler: (ev: WindowEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function on(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function on(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void {
+  const list = target instanceof DOMCollection ? target.elements : [target as any];
+  const unbinders = list.map(t => onDirect(t as any, types, handler, options));
+  return () => { for (const u of unbinders) u(); };
+}
+
+export function once<K extends keyof GlobalEventHandlersEventMap>(target: Element | DOMCollection, types: K, handler: (ev: GlobalEventHandlersEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function once<K extends keyof DocumentEventMap>(target: Document, types: K, handler: (ev: DocumentEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function once<K extends keyof WindowEventMap>(target: Window, types: K, handler: (ev: WindowEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function once(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void;
+export function once(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void {
+  const opts: AddEventListenerOptions = Object.assign({ once: true }, typeof options === 'object' ? options : {});
+  return on(target, types, handler, opts);
+}
+
+export function off(target: EventTargetish | DOMCollection, types?: string, handler?: (ev: Event) => void): void {
+  const list = target instanceof DOMCollection ? target.elements : [target as any];
+  if (!types) {
+    list.forEach(t => removeAllManaged(t as any));
+    return;
+  }
+  list.forEach(t => removeManaged(t as any, types, handler as any));
+}
+
+export function ready(fn: () => void): void { domReady(fn); }
+
+// ——— Internal helpers ———
+function setAttr(el: Element, key: string, value: any) {
+  if (key === 'style' && typeof value === 'object') Object.assign((el as HTMLElement).style, value);
+  else if (key in el) (el as any)[key] = value;
+  else if (value === false || value == null) el.removeAttribute(key);
+  else el.setAttribute(key, String(value));
+}
+
+function appendChildren(el: Element, kids: MaybeArray<string | Node | DOMCollection>) {
+  for (const child of (Array.isArray(kids) ? kids : [kids])) {
+    if (child == null) continue;
+    if (typeof child === 'string') el.insertAdjacentHTML('beforeend', child);
+    else if (child instanceof DOMCollection) child.elements.forEach(n => el.appendChild(n));
+    else el.appendChild(child);
+  }
+}
+

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,95 +1,7 @@
 import { MaybeArray, Selector, EventTargetish } from './types';
-import { isString, isElement, isDocument, isWindow, hasDOM } from './utils';
 import { DOMCollection } from './collection';
 import { use } from './plugins';
-import { onDirect, removeManaged, addManaged, removeAllManaged, ready as domReady } from './events';
-
-// ——— Core selector ———
-export function dom<T extends Element = Element>(input?: Selector<T>, context?: Element | Document | DOMCollection): DOMCollection<T> {
-  if (!input) return new DOMCollection([]);
-  if (isString(input)) {
-    const s = input.trim();
-    if (s.startsWith('<') && s.endsWith('>')) return fromHTML(s) as unknown as DOMCollection<T>;
-    if (!context) return hasDOM() ? new DOMCollection(document.querySelectorAll(s) as any) : new DOMCollection([] as any);
-    if (context instanceof DOMCollection) {
-      const found: Element[] = [] as any;
-      for (const el of context.elements) found.push(...(hasDOM() ? (el.querySelectorAll(s) as any) : []));
-      return new DOMCollection(found) as unknown as DOMCollection<T>;
-    }
-    if (context instanceof Element) return hasDOM() ? new DOMCollection(context.querySelectorAll(s) as any) as unknown as DOMCollection<T> : new DOMCollection([] as any);
-    return hasDOM() ? new DOMCollection((context as Document).querySelectorAll(s) as any) as unknown as DOMCollection<T> : new DOMCollection([] as any);
-  }
-  if (isElement(input)) return new DOMCollection([input as T]);
-  if (input instanceof NodeList || Array.isArray(input)) return new DOMCollection(input as any);
-  if (isDocument(input)) return new DOMCollection([input.documentElement as any]);
-  if (isWindow(input)) return new DOMCollection([input.document.documentElement as any]);
-  return new DOMCollection([]) as DOMCollection<T>;
-}
-
-// ——— HTML string to elements ———
-export function fromHTML(html: string): DOMCollection {
-  if (!hasDOM()) return new DOMCollection([]);
-  const tpl = document.createElement('template');
-  tpl.innerHTML = html.trim();
-  return new DOMCollection(Array.from(tpl.content.children) as any);
-}
-
-// ——— Element creation ———
-export function create(tag: string, attrs?: Record<string, any> | null, children?: MaybeArray<string | Node | DOMCollection>): Element {
-  if (!hasDOM()) throw new Error('create(tag) requires a DOM environment');
-  const el = document.createElement(tag);
-  if (attrs) for (const [k, v] of Object.entries(attrs)) setAttr(el, k, v);
-  if (children) appendChildren(el, children);
-  return el;
-}
-
-// ——— Event helpers ———
-export function on<K extends keyof GlobalEventHandlersEventMap>(target: Element | DOMCollection, types: K, handler: (ev: GlobalEventHandlersEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on<K extends keyof DocumentEventMap>(target: Document, types: K, handler: (ev: DocumentEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on<K extends keyof WindowEventMap>(target: Window, types: K, handler: (ev: WindowEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void {
-  const list = target instanceof DOMCollection ? target.elements : [target as any];
-  const unbinders = list.map(t => onDirect(t as any, types, handler, options));
-  return () => { for (const u of unbinders) u(); };
-}
-
-export function once<K extends keyof GlobalEventHandlersEventMap>(target: Element | DOMCollection, types: K, handler: (ev: GlobalEventHandlersEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once<K extends keyof DocumentEventMap>(target: Document, types: K, handler: (ev: DocumentEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once<K extends keyof WindowEventMap>(target: Window, types: K, handler: (ev: WindowEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void {
-  const opts: AddEventListenerOptions = Object.assign({ once: true }, typeof options === 'object' ? options : {});
-  return on(target, types, handler, opts);
-}
-
-export function off(target: EventTargetish | DOMCollection, types?: string, handler?: (ev: Event) => void): void {
-  const list = target instanceof DOMCollection ? target.elements : [target as any];
-  if (!types) {
-    list.forEach(t => removeAllManaged(t as any));
-    return;
-    }
-  list.forEach(t => removeManaged(t as any, types, handler as any));
-}
-
-export function ready(fn: () => void): void { domReady(fn); }
-
-// ——— Helper functions ———
-function setAttr(el: Element, key: string, value: any) {
-  if (key === 'style' && typeof value === 'object') Object.assign((el as HTMLElement).style, value);
-  else if (key in el) (el as any)[key] = value;
-  else if (value === false || value == null) el.removeAttribute(key);
-  else el.setAttribute(key, String(value));
-}
-
-function appendChildren(el: Element, kids: MaybeArray<string | Node | DOMCollection>) {
-  for (const child of (Array.isArray(kids) ? kids : [kids])) {
-    if (child == null) continue;
-    if (typeof child === 'string') el.insertAdjacentHTML('beforeend', child);
-    else if (child instanceof DOMCollection) child.elements.forEach(n => el.appendChild(n));
-    else el.appendChild(child);
-  }
-}
+import { dom, fromHTML, create, on, once, off, ready } from './core-api';
 
 // ——— Core API (default export) ———
 export interface Dom {
@@ -113,5 +25,6 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
 
 // ——— Exports ———
 export { DOMCollection, use };
+export { dom, fromHTML, create, on, once, off, ready } from './core-api';
 export type Plugin = (api: Dom) => void;
 export default api;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,121 +1,14 @@
 import { MaybeArray, Selector, EventTargetish, Handler } from './types';
-import { isString, isElement, isDocument, isWindow, debounce, throttle, nextTick, raf, rafThrottle, hasDOM } from './utils';
+import { debounce, throttle, nextTick, raf, rafThrottle } from './utils';
 import { DOMCollection } from './collection';
 import { renderTemplate, useTemplate, tpl, mountTemplate, escapeHTML, unsafeHTML } from './template';
 import { serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid } from './forms';
 import { animate, animations, installAnimationMethods } from './motion';
 import { http } from './http';
 import { use } from './plugins';
-import { onDirect, removeManaged, removeAllManaged, ready as domReady } from './events';
+import { dom, fromHTML, create, on, once, off, ready } from './core-api';
 import { onIntersect, onResize, onMutation } from './observers';
 import { scrollIntoView, scrollIntoViewIfNeeded } from './scroll';
-
-// ——— Core selector ———
-/**
- * Select DOM elements or create from HTML.
- *
- * - Accepts CSS selectors, Elements, NodeLists/arrays, Document or Window
- * - Optional `context` limits CSS selection scope
- * - Supports manual generic to type the resulting collection
- *
- * Examples:
- *  dom<HTMLButtonElement>('#save');
- *  dom('button');
- *  dom('<div class="x"></div>');
- */
-export function dom<T extends Element = Element>(input?: Selector<T>, context?: Element | Document | DOMCollection): DOMCollection<T> {
-  if (!input) return new DOMCollection([]);
-  if (isString(input)) {
-    const s = input.trim();
-    if (s.startsWith('<') && s.endsWith('>')) return fromHTML(s) as unknown as DOMCollection<T>;
-    // Contextual selection
-    if (!context) return hasDOM() ? new DOMCollection(document.querySelectorAll(s) as any) : new DOMCollection([] as any);
-    if (context instanceof DOMCollection) {
-      const found: Element[] = [] as any;
-      for (const el of context.elements) found.push(...(hasDOM() ? (el.querySelectorAll(s) as any) : []));
-      return new DOMCollection(found) as unknown as DOMCollection<T>;
-    }
-    if (context instanceof Element) return hasDOM() ? new DOMCollection(context.querySelectorAll(s) as any) as unknown as DOMCollection<T> : new DOMCollection([] as any);
-    return hasDOM() ? new DOMCollection((context as Document).querySelectorAll(s) as any) as unknown as DOMCollection<T> : new DOMCollection([] as any);
-  }
-  if (isElement(input)) return new DOMCollection([input as T]);
-  if (input instanceof NodeList || Array.isArray(input)) return new DOMCollection(input as any);
-  if (isDocument(input)) return new DOMCollection([input.documentElement as any]);
-  if (isWindow(input)) return new DOMCollection([input.document.documentElement as any]);
-  return new DOMCollection([]) as DOMCollection<T>;
-}
-
-// ——— HTML string to elements ———
-export function fromHTML(html: string): DOMCollection {
-  if (!hasDOM()) return new DOMCollection([]);
-  const tpl = document.createElement('template');
-  tpl.innerHTML = html.trim();
-  return new DOMCollection(Array.from(tpl.content.children) as any);
-}
-
-// ——— Element creation ———
-export function create(tag: string, attrs?: Record<string, any> | null, children?: MaybeArray<string | Node | DOMCollection>): Element {
-  if (!hasDOM()) throw new Error('create(tag) requires a DOM environment');
-  const el = document.createElement(tag);
-  if (attrs) for (const [k, v] of Object.entries(attrs)) setAttr(el, k, v);
-  if (children) appendChildren(el, children);
-  return el;
-}
-
-// ——— Event helpers ———
-/**
- * Bind event listener(s) to an Element/Document/Window or a DOMCollection.
- *
- * - Supports multiple space-separated event types and namespaces (e.g. 'click.ns')
- * - Returns an unbind function
- * - Event type maps to proper DOM event type for strong typing
- */
-export function on<K extends keyof GlobalEventHandlersEventMap>(target: Element | DOMCollection, types: K, handler: (ev: GlobalEventHandlersEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on<K extends keyof DocumentEventMap>(target: Document, types: K, handler: (ev: DocumentEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on<K extends keyof WindowEventMap>(target: Window, types: K, handler: (ev: WindowEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function on(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void {
-  const list = target instanceof DOMCollection ? target.elements : [target as any];
-  const unbinders = list.map(t => onDirect(t as any, types, handler, options));
-  return () => { for (const u of unbinders) u(); };
-}
-
-export function once<K extends keyof GlobalEventHandlersEventMap>(target: Element | DOMCollection, types: K, handler: (ev: GlobalEventHandlersEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once<K extends keyof DocumentEventMap>(target: Document, types: K, handler: (ev: DocumentEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once<K extends keyof WindowEventMap>(target: Window, types: K, handler: (ev: WindowEventMap[K]) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void;
-export function once(target: EventTargetish | DOMCollection, types: string, handler: (ev: Event) => void, options?: boolean | AddEventListenerOptions): () => void {
-  const opts: AddEventListenerOptions = Object.assign({ once: true }, typeof options === 'object' ? options : {});
-  return on(target, types, handler, opts);
-}
-
-export function off(target: EventTargetish | DOMCollection, types?: string, handler?: (ev: Event) => void): void {
-  const list = target instanceof DOMCollection ? target.elements : [target as any];
-  if (!types) {
-    list.forEach(t => removeAllManaged(t as any));
-    return;
-  }
-  list.forEach(t => removeManaged(t as any, types, handler as any));
-}
-
-export function ready(fn: () => void): void { domReady(fn); }
-
-// ——— Helper functions ———
-function setAttr(el: Element, key: string, value: any) {
-  if (key === 'style' && typeof value === 'object') Object.assign((el as HTMLElement).style, value);
-  else if (key in el) (el as any)[key] = value;
-  else if (value === false || value == null) el.removeAttribute(key);
-  else el.setAttribute(key, String(value));
-}
-
-function appendChildren(el: Element, kids: MaybeArray<string | Node | DOMCollection>) {
-  for (const child of (Array.isArray(kids) ? kids : [kids])) {
-    if (child == null) continue;
-    if (typeof child === 'string') el.insertAdjacentHTML('beforeend', child);
-    else if (child instanceof DOMCollection) child.elements.forEach(n => el.appendChild(n));
-    else el.appendChild(child);
-  }
-}
 
 // ——— API bag (default export) ———
 export interface Dom {
@@ -178,5 +71,6 @@ installAnimationMethods();
 
 // ——— Exports ———
 export { DOMCollection, renderTemplate, useTemplate, tpl, mountTemplate, escapeHTML, unsafeHTML, serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid, animate, animations, http, use, debounce, throttle, nextTick, raf, rafThrottle, onIntersect, onResize, onMutation, scrollIntoView, scrollIntoViewIfNeeded };
+export { dom, fromHTML, create, on, once, off, ready } from './core-api';
 export type Plugin = (api: Dom) => void;
 export default api;

--- a/tests/events-delegated.test.mjs
+++ b/tests/events-delegated.test.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import { JSDOM } from 'jsdom';
+import { on, once } from '../dist/index.js';
+
+console.log('\n🧪 Testing top-level delegated events (document/window)...');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    passed++;
+  } catch (error) {
+    console.error(`❌ ${name}: ${error.message}`);
+    failed++;
+  }
+}
+
+// Setup DOM
+const dom = new JSDOM('<!doctype html><html><body><ul id="list"><li class="item"><a class="link">A</a></li></ul></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.Element = dom.window.Element;
+global.HTMLElement = dom.window.HTMLElement;
+
+test('Delegated handler on document fires for matching target', () => {
+  const calls = [];
+  const stop = on(document, 'click.test', 'a.link', (e, el) => { calls.push(el); });
+  const a = document.querySelector('a.link');
+  a.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  stop();
+  if (calls.length !== 1) throw new Error('Expected delegated handler to fire exactly once');
+});
+
+test('once() delegated fires only once', () => {
+  let n = 0;
+  once(document, 'click', 'a.link', () => { n++; });
+  const a = document.querySelector('a.link');
+  a.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  a.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+  if (n !== 1) throw new Error('Expected once delegated handler to fire only once');
+});
+
+console.log(`\n📊 Top-level delegation: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/qol-helpers.test.mjs
+++ b/tests/qol-helpers.test.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { JSDOM } from 'jsdom';
+import api from '../dist/index.js';
+
+console.log('\n🧪 Testing QoL helpers: dataset, aria, beforeEach/afterEach...');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    passed++;
+  } catch (error) {
+    console.error(`❌ ${name}: ${error.message}`);
+    failed++;
+  }
+}
+
+// Setup DOM
+const dom = new JSDOM('<!doctype html><html><body><div id="a"></div><div id="b"></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.Element = dom.window.Element;
+global.HTMLElement = dom.window.HTMLElement;
+
+test('dataset(map) sets multiple data-* attributes', () => {
+  const $els = api('#a, #b');
+  $els.dataset({ userId: 123, 'data-active': true });
+  const a = document.getElementById('a');
+  const b = document.getElementById('b');
+  if (a.getAttribute('data-user-id') !== '123') throw new Error('data-user-id not set on #a');
+  if (b.getAttribute('data-user-id') !== '123') throw new Error('data-user-id not set on #b');
+  if (a.getAttribute('data-active') !== 'true') throw new Error('data-active not set on #a');
+});
+
+test('dataset() reads dataset from first element', () => {
+  const a = document.getElementById('a');
+  a.setAttribute('data-mode', 'dark');
+  const ds = api('#a').dataset();
+  if (ds.mode !== 'dark') throw new Error('dataset() did not read data-mode');
+});
+
+test('aria(name, value) sets aria-* and aria(map) merges', () => {
+  const $a = api('#a');
+  $a.aria('busy', true).aria({ label: 'X', 'aria-checked': false });
+  const a = document.getElementById('a');
+  if (a.getAttribute('aria-busy') !== 'true') throw new Error('aria-busy not set to true');
+  if (a.getAttribute('aria-label') !== 'X') throw new Error('aria-label not set');
+  if (a.getAttribute('aria-checked') !== 'false') throw new Error('aria-checked not set false');
+  if ($a.aria('label') !== 'X') throw new Error('aria(name) did not read back value');
+});
+
+test('beforeEach/afterEach call the callback for each element', () => {
+  const $els = api('#a, #b');
+  let before = 0, after = 0;
+  $els.beforeEach(() => before++).afterEach(() => after++);
+  if (before !== 2 || after !== 2) throw new Error('beforeEach/afterEach did not run for each element');
+});
+
+console.log(`\n📊 QoL tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/trigger-init.test.mjs
+++ b/tests/trigger-init.test.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { JSDOM } from 'jsdom';
+import api from '../dist/index.js';
+
+console.log('\n🧪 Testing trigger() init options (EventInit | CustomEventInit)...');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    passed++;
+  } catch (error) {
+    console.error(`❌ ${name}: ${error.message}`);
+    failed++;
+  }
+}
+
+// Setup DOM
+const dom = new JSDOM('<!doctype html><html><body><div id="root"><button id="btn"></button></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.Element = dom.window.Element;
+global.HTMLElement = dom.window.HTMLElement;
+
+test('trigger() with detail uses CustomEvent and bubbles by default', () => {
+  const btn = document.getElementById('btn');
+  const root = document.getElementById('root');
+  let receivedDetail;
+  root.addEventListener('go', (e) => {
+    receivedDetail = (e instanceof dom.window.CustomEvent) ? e.detail : undefined;
+  });
+  api(btn).trigger('go', { msg: 'ok' });
+  if (!receivedDetail || receivedDetail.msg !== 'ok') throw new Error('CustomEvent detail not received at parent');
+});
+
+test('trigger() honors cancelable option for EventInit', () => {
+  const btn = document.getElementById('btn');
+  let prevented = false;
+  btn.addEventListener('save', (e) => {
+    e.preventDefault();
+    prevented = e.defaultPrevented;
+  });
+  api(btn).trigger('save', { cancelable: true });
+  if (!prevented) throw new Error('Expected defaultPrevented when cancelable: true and preventDefault() called');
+});
+
+test('trigger() accepts CustomEventInit directly', () => {
+  const btn = document.getElementById('btn');
+  let got = null;
+  btn.addEventListener('hello', (e) => {
+    got = e.detail;
+  });
+  api(btn).trigger('hello', { detail: 42, bubbles: false });
+  if (got !== 42) throw new Error('Expected detail to be 42');
+});
+
+console.log(`\n📊 trigger() tests: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
This pull request introduces several new convenience helpers and event delegation features to the DOM manipulation library, along with improvements to documentation and package configuration. The main changes include new `.dataset()` and `.aria()` methods for easier attribute management, enhanced event delegation and triggering capabilities, and a refactoring that moves core API logic to a new file for better maintainability. The documentation and package files have also been updated to reflect these enhancements.

### New API features

* Added `.dataset(map)` and `.aria(name[, value])/aria(map)` helpers to `DOMCollection` for setting multiple `data-*` and `aria-*` attributes efficiently. (`src/collection.ts`, `REFERENCE.md`, `README.md`) [[1]](diffhunk://#diff-13b5100fa0acd2c3b6be6e5478d6ccf278ff05a0d74635abeb9720e6823c4642R962-R1010) [[2]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aR68-R69) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R132)
* Enhanced `.trigger(type[, init])` to accept `EventInit | CustomEventInit | any`, defaulting to `{ bubbles: true }`, and supporting passing an event instance directly. (`src/collection.ts`, `REFERENCE.md`, `README.md`) [[1]](diffhunk://#diff-13b5100fa0acd2c3b6be6e5478d6ccf278ff05a0d74635abeb9720e6823c4642L899-R923) [[2]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL81-R91) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R132)

### Event delegation and helpers

* Improved event delegation: `.on/once/off` now support direct and delegated forms for `Element`, `Document`, and `Window`, including multiple event types and namespaces. (`src/core-api.ts`, `REFERENCE.md`, `README.md`) [[1]](diffhunk://#diff-fe480a6c964d3e2f999fede67b9f90a66f7ba9aea6701acabf4c49bdd2f9b916R1-R117) [[2]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL40-R42) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R132)
* Added `.beforeEach(fn)` and `.afterEach(fn)` as aliases to `.each(fn)` for improved chain readability. (`src/collection.ts`, `REFERENCE.md`) [[1]](diffhunk://#diff-13b5100fa0acd2c3b6be6e5478d6ccf278ff05a0d74635abeb9720e6823c4642R962-R1010) [[2]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL81-R91)

### Refactoring and documentation

* Moved core API logic from `src/core.ts` to a new `src/core-api.ts` file, cleaning up exports and improving maintainability. (`src/core.ts`) [[1]](diffhunk://#diff-033ecd338eec0994fe53c0896219baee901e20068b8fbe6259a23d5759584b06L2-R4) [[2]](diffhunk://#diff-033ecd338eec0994fe53c0896219baee901e20068b8fbe6259a23d5759584b06R28)
* Updated documentation in `README.md` and `REFERENCE.md` to describe new features and event delegation capabilities. [[1]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL40-R42) [[2]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aR68-R69) [[3]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL81-R91) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R132)

### Package configuration

* Updated `package.json` to version `1.6.6`, added new test scripts for delegated events, trigger/init, and helpers, and included documentation files in the package. (`package.json`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L80-R90)