### PR TITLE
new animation and observer utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ import { onSubmit, serializeForm, toFormData, toQueryString, setForm, resetForm,
 import { animate, animations } from "@dmitrijkiltau/dom.js/motion";
 import { debounce, throttle, nextTick, raf, rafThrottle } from "@dmitrijkiltau/dom.js/utils";
 import { onIntersect, inView, onResize, onMutation } from "@dmitrijkiltau/dom.js/observers";
-import { scrollIntoView, scrollIntoViewIfNeeded } from "@dmitrijkiltau/dom.js/scroll";
+import { scrollIntoView, scrollIntoViewIfNeeded, lockScroll, unlockScroll } from "@dmitrijkiltau/dom.js/scroll";
 ```
 
 ## Core API Highlights
@@ -305,7 +305,7 @@ await dom('#row').withVisible('flex').slideDown(200);
 ```js
 import { debounce, throttle, nextTick, raf, rafThrottle } from "@dmitrijkiltau/dom.js/utils";
 import { onIntersect, onResize, onMutation } from "@dmitrijkiltau/dom.js/observers";
-import { scrollIntoView, scrollIntoViewIfNeeded } from "@dmitrijkiltau/dom.js/scroll";
+import { scrollIntoView, scrollIntoViewIfNeeded, lockScroll, unlockScroll } from "@dmitrijkiltau/dom.js/scroll";
 
 const onType = debounce(() => {/* ... */}, 150);
 await nextTick(); await raf();
@@ -323,6 +323,16 @@ io.leave((el) => {
 });
 // Later: io.stop(); // disconnects observer and clears handlers
 scrollIntoView("#details", { behavior: "smooth", block: "start" });
+
+// Lock page scroll while a modal is open
+lockScroll();
+// ... open modal ...
+unlockScroll();
+
+// Lock a specific scrollable container
+lockScroll('#panel');
+// ...
+unlockScroll('#panel');
 ```
 
 ## SSR (Server‑Safe)

--- a/README.md
+++ b/README.md
@@ -274,10 +274,25 @@ const users = await r.json();
 ## Motion
 
 ```js
-import { animate, animations } from "@dmitrijkiltau/dom.js/motion";
+import { animate, animations, sequence, stagger } from "@dmitrijkiltau/dom.js/motion";
 
 const [kf, op] = animations.fadeIn(250);
 await animate(dom(".box").el(), kf, op).finished;
+
+// Sequence multiple animations on the same element
+await dom('#card').sequence([
+  animations.slideDown(200),
+  100, // wait 100ms
+  animations.pulse(400)
+]);
+
+// Stagger across a list
+await dom('.item').stagger(100, (el, i) =>
+  dom(el).animate([
+    { opacity: 0, transform: 'translateY(8px)' },
+    { opacity: 1, transform: 'translateY(0px)' }
+  ], { duration: 300, fill: 'forwards' })
+);
 ```
 
 ## Utilities & Observers

--- a/README.md
+++ b/README.md
@@ -293,6 +293,11 @@ await dom('.item').stagger(100, (el, i) =>
     { opacity: 1, transform: 'translateY(0px)' }
   ], { duration: 300, fill: 'forwards' })
 );
+
+// Ensure visibility before animating (e.g., with reduced motion)
+await dom('.panel').withVisible().fadeIn(250);
+// Custom display value
+await dom('#row').withVisible('flex').slideDown(200);
 ```
 
 ## Utilities & Observers

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ import { renderTemplate, useTemplate, tpl } from "@dmitrijkiltau/dom.js/template
 import { onSubmit, serializeForm, toFormData, toQueryString, setForm, resetForm, validateForm } from "@dmitrijkiltau/dom.js/forms";
 import { animate, animations } from "@dmitrijkiltau/dom.js/motion";
 import { debounce, throttle, nextTick, raf, rafThrottle } from "@dmitrijkiltau/dom.js/utils";
-import { onIntersect, onResize, onMutation } from "@dmitrijkiltau/dom.js/observers";
+import { onIntersect, inView, onResize, onMutation } from "@dmitrijkiltau/dom.js/observers";
 import { scrollIntoView, scrollIntoViewIfNeeded } from "@dmitrijkiltau/dom.js/scroll";
 ```
 
@@ -311,6 +311,17 @@ const onType = debounce(() => {/* ... */}, 150);
 await nextTick(); await raf();
 
 const stop1 = onIntersect(".watch", (entry, el) => {/* ... */}, { threshold: 0.1 });
+
+// In‑view sugar: subscribe to enter/leave
+const io = inView('.card', { threshold: 0.25, once: true });
+const unEnter = io.enter((el, entry) => {
+  // Called once per element when it reaches 25% visibility
+  el.classList.add('reveal');
+});
+io.leave((el) => {
+  // Called when it drops below 25% (not called if once:true already unobserved)
+});
+// Later: io.stop(); // disconnects observer and clears handlers
 scrollIntoView("#details", { behavior: "smooth", block: "start" });
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,7 +14,7 @@ This reference provides a compact, scan-friendly overview of dom.js: entries, mo
 | `@dmitrijkiltau/dom.js/motion`          | Animations and composition helpers                   | Yes                   | ~6.5 KB                | Web Animations |
 | `@dmitrijkiltau/dom.js/utils`           | debounce/throttle/nextTick/raf(/rafThrottle)         | Yes                   | tiny                   | Scheduling & rate‑limit |
 | `@dmitrijkiltau/dom.js/observers`       | onIntersect/onResize/onMutation wrappers             | Yes                   | tiny                   | Observers |
-| `@dmitrijkiltau/dom.js/scroll`          | scrollIntoView helpers                               | Yes                   | tiny                   | Scrolling |
+| `@dmitrijkiltau/dom.js/scroll`          | scrollIntoView + scroll lock                         | Yes                   | tiny                   | Scrolling |
 | `@dmitrijkiltau/dom.js/server`          | Server‑safe entry (no real DOM ops)                  | Yes                   | —                      | SSR/Node import |
 
 Note: “Import‑safe on server” means modules do not access `window`/`document` at import time. DOM‑touching functions still require a browser.
@@ -30,7 +30,7 @@ Note: “Import‑safe on server” means modules do not access `window`/`docume
 | `motion`                     | `animate`, `animations`, `sequence`, `stagger` |
 | `utils`                      | `debounce`, `throttle`, `nextTick`, `raf`, `rafThrottle` (plus helpers like `toArray`, `isString`) |
 | `observers`                  | `onIntersect`, `onResize`, `onMutation` |
-| `scroll`                     | `scrollIntoView`, `scrollIntoViewIfNeeded` |
+| `scroll`                     | `scrollIntoView`, `scrollIntoViewIfNeeded`, `lockScroll`, `unlockScroll` |
 | `server`                     | `default` (SSR‑safe `dom()` + `http` + utils; DOM ops are guarded) |
 
 ## Top‑Level `dom()` Object (full bundle and core)
@@ -163,7 +163,7 @@ Utilities:
 
 - Utils: `debounce(fn, wait, opts?)`, `throttle(fn, wait, opts?)`, `nextTick(cb?)`, `raf(cb?)`, `rafThrottle(fn)`
 - Observers: `onIntersect(targets, cb, opts?)`, `inView(targets, { threshold, once, ... }?)`, `onResize(targets, cb, opts?)`, `onMutation(targets, cb, opts?)`
-- Scroll: `scrollIntoView(target, opts)`, `scrollIntoViewIfNeeded(target, opts)` and collection counterparts
+- Scroll: `scrollIntoView(target, opts)`, `scrollIntoViewIfNeeded(target, opts)` (also available on collections); `lockScroll(el?)`, `unlockScroll(el?)`
 
 ## Typing & Plugins
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -11,7 +11,7 @@ This reference provides a compact, scan-friendly overview of dom.js: entries, mo
 | `@dmitrijkiltau/dom.js/http`            | HTTP client                                          | Yes                   | ~0.7 KB                | API calls only |
 | `@dmitrijkiltau/dom.js/template`        | Template engine (render/use/mount, escape helpers)   | Yes                   | ~2.8 KB                | HTML templates |
 | `@dmitrijkiltau/dom.js/forms`           | Form serialize/populate/reset/validate/submit        | Yes                   | ~1.7 KB                | Forms utilities |
-| `@dmitrijkiltau/dom.js/motion`          | Animations + collection helpers installer            | Yes                   | ~6.5 KB                | Web Animations |
+| `@dmitrijkiltau/dom.js/motion`          | Animations and composition helpers                   | Yes                   | ~6.5 KB                | Web Animations |
 | `@dmitrijkiltau/dom.js/utils`           | debounce/throttle/nextTick/raf(/rafThrottle)         | Yes                   | tiny                   | Scheduling & rate‑limit |
 | `@dmitrijkiltau/dom.js/observers`       | onIntersect/onResize/onMutation wrappers             | Yes                   | tiny                   | Observers |
 | `@dmitrijkiltau/dom.js/scroll`          | scrollIntoView helpers                               | Yes                   | tiny                   | Scrolling |
@@ -27,7 +27,7 @@ Note: “Import‑safe on server” means modules do not access `window`/`docume
 | `template`                   | `renderTemplate`, `useTemplate`, `mountTemplate`, `hydrateTemplate`, `tpl`, `setTemplateDevMode`, `escapeHTML`, `unsafeHTML` |
 | `forms`                      | `serializeForm`, `toFormData`, `toQueryString`, `setForm`, `resetForm`, `validateForm`, `onSubmit`, `isValid` |
 | `http`                       | `http`, `appendQuery` |
-| `motion`                     | `animate`, `animations`, `installAnimationMethods` |
+| `motion`                     | `animate`, `animations`, `sequence`, `stagger` |
 | `utils`                      | `debounce`, `throttle`, `nextTick`, `raf`, `rafThrottle` (plus helpers like `toArray`, `isString`) |
 | `observers`                  | `onIntersect`, `onResize`, `onMutation` |
 | `scroll`                     | `scrollIntoView`, `scrollIntoViewIfNeeded` |
@@ -156,7 +156,8 @@ Utilities:
 - Presets: `animations.fadeIn/fadeOut/slideUp/slideDown/pulse/shake(duration?)`
 - Sequences: `sequence(steps)` → returns runner `(el, idx) => Promise<void>`; `steps` can be `[keyframes, options]`, function `(el, idx) => [keyframes, options]`, or a `number` delay in ms.
 - Stagger: `stagger(stepMs, fn)` → returns runner for collections/arrays; runs `fn(el, idx)` per element with `idx * stepMs` delay, integrated with per‑element queue. `fn` may return an `Animation` or a `Promise`.
-- Install collection helpers: `installAnimationMethods()` → adds `.fadeIn/.fadeOut/.fadeToggle/.slideUp/.slideDown/.slideToggle/.pulse/.shake()`, plus `.sequence(steps)` and `.stagger(stepMs, fn)`; all helpers are queued per‑element and return `Promise<DOMCollection>`
+- Collection helpers (.fadeIn/.fadeOut/.fadeToggle/.slideUp/.slideDown/.slideToggle/.pulse/.shake/.sequence/.stagger) are available on `DOMCollection` in the full bundle; they are queued per‑element and return `Promise<DOMCollection>`
+- Visibility wrapper: `withVisible([display])` returns animation helpers that make elements visible (set `display`) before animating — ensures correct state when reduced‑motion collapses durations to 0.
 
 ## Utilities & Observers & Scroll
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -154,7 +154,9 @@ Utilities:
 
 - Low‑level: `animate(el, keyframes, options)` → `Animation`
 - Presets: `animations.fadeIn/fadeOut/slideUp/slideDown/pulse/shake(duration?)`
-- Install collection helpers: `installAnimationMethods()` → adds `.fadeIn/.fadeOut/.fadeToggle/.slideUp/.slideDown/.slideToggle/.pulse/.shake()`; helpers are queued per‑element and return `Promise<DOMCollection>`
+- Sequences: `sequence(steps)` → returns runner `(el, idx) => Promise<void>`; `steps` can be `[keyframes, options]`, function `(el, idx) => [keyframes, options]`, or a `number` delay in ms.
+- Stagger: `stagger(stepMs, fn)` → returns runner for collections/arrays; runs `fn(el, idx)` per element with `idx * stepMs` delay, integrated with per‑element queue. `fn` may return an `Animation` or a `Promise`.
+- Install collection helpers: `installAnimationMethods()` → adds `.fadeIn/.fadeOut/.fadeToggle/.slideUp/.slideDown/.slideToggle/.pulse/.shake()`, plus `.sequence(steps)` and `.stagger(stepMs, fn)`; all helpers are queued per‑element and return `Promise<DOMCollection>`
 
 ## Utilities & Observers & Scroll
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -162,7 +162,7 @@ Utilities:
 ## Utilities & Observers & Scroll
 
 - Utils: `debounce(fn, wait, opts?)`, `throttle(fn, wait, opts?)`, `nextTick(cb?)`, `raf(cb?)`, `rafThrottle(fn)`
-- Observers: `onIntersect(targets, cb, opts?)`, `onResize(targets, cb, opts?)`, `onMutation(targets, cb, opts?)`
+- Observers: `onIntersect(targets, cb, opts?)`, `inView(targets, { threshold, once, ... }?)`, `onResize(targets, cb, opts?)`, `onMutation(targets, cb, opts?)`
 - Scroll: `scrollIntoView(target, opts)`, `scrollIntoViewIfNeeded(target, opts)` and collection counterparts
 
 ## Typing & Plugins

--- a/docs/data/navigation.js
+++ b/docs/data/navigation.js
@@ -1,17 +1,4 @@
-// Navigation data
-export const navigationItems = [
-  { title: 'Getting Started', href: '#getting-started' },
-  { title: 'Installation', href: '#installation' },
-  { title: 'Modular Architecture', href: '#modular-architecture' },
-  { title: 'Core API', href: '#core-api' },
-  { title: 'DOM Manipulation', href: '#dom-manipulation' },
-  { title: 'Layout & Geometry', href: '#layout-geometry' },
-  { title: 'Utilities', href: '#utilities' },
-  { title: 'Observers', href: '#observers' },
-  { title: 'Templates', href: '#templates' },
-  { title: 'Forms', href: '#forms' },
-  { title: 'Events', href: '#events' },
-  { title: 'HTTP', href: '#http' },
-  { title: 'Animation', href: '#animation' },
-  { title: 'Plugin System', href: '#plugins' }
-];
+// Navigation data derived from sections to ensure consistent ordering
+import { sections } from './sections.js';
+
+export const navigationItems = sections.map(s => ({ title: s.title, href: `#${s.id}` }));

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom.js-docs",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom.js-docs",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom.js-docs",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/docs/sections/animation.js
+++ b/docs/sections/animation.js
@@ -339,45 +339,43 @@ animation.addEventListener('finish', () => {
 
   dom('#pulse-demo').on('click', () => {
     resetBoxes();
-    dom('#appear-box').animate([
-      { transform: 'scale(1)', opacity: 1 },
-      { transform: 'scale(1.1)', opacity: 0.8 },
-      { transform: 'scale(1)', opacity: 1 }
-    ], {
-      duration: 800,
-      iterations: 3,
-      easing: 'ease-in-out'
-    });
+    dom('#appear-box').pulse(800);
   });
 
-  // Sequential animation
+  // Sequential animation via .sequence()
   dom('#sequence-demo').on('click', async () => {
     resetBoxes();
-    const box = dom('#sequence-box');
-
-    // Step 1: Slide right
-    await box.animate([
-      { transform: 'translateX(0px)' },
-      { transform: 'translateX(100px)' }
-    ], { duration: 800, fill: 'forwards' }).finished;
-
-    // Step 2: Slide down
-    await box.animate([
-      { transform: 'translateX(100px) translateY(0px)' },
-      { transform: 'translateX(100px) translateY(60px)' }
-    ], { duration: 800, fill: 'forwards' }).finished;
-
-    // Step 3: Scale and rotate
-    await box.animate([
-      { transform: 'translateX(100px) translateY(60px) scale(1) rotate(0deg)' },
-      { transform: 'translateX(100px) translateY(60px) scale(1.5) rotate(180deg)' }
-    ], { duration: 1000, fill: 'forwards' }).finished;
-
-    // Step 4: Return home with fade
-    await box.animate([
-      { transform: 'translateX(100px) translateY(60px) scale(1.5) rotate(180deg)', opacity: 1 },
-      { transform: 'translateX(0px) translateY(0px) scale(1) rotate(0deg)', opacity: 1 }
-    ], { duration: 1200, fill: 'forwards' }).finished;
+    await dom('#sequence-box').sequence([
+      [
+        [
+          { transform: 'translateX(0px)' },
+          { transform: 'translateX(100px)' }
+        ],
+        { duration: 800, fill: 'forwards' }
+      ],
+      [
+        [
+          { transform: 'translateX(100px) translateY(0px)' },
+          { transform: 'translateX(100px) translateY(60px)' }
+        ],
+        { duration: 800, fill: 'forwards' }
+      ],
+      [
+        [
+          { transform: 'translateX(100px) translateY(60px) rotate(0deg)' },
+          { transform: 'translateX(100px) translateY(60px) rotate(180deg)' }
+        ],
+        { duration: 800, fill: 'forwards' }
+      ],
+      200,
+      [
+        [
+          { transform: 'translateX(100px) translateY(60px) scale(1) rotate(180deg)', opacity: 1 },
+          { transform: 'translateX(0px) translateY(0px) scale(1) rotate(0deg)', opacity: 1 }
+        ],
+        { duration: 1200, fill: 'forwards' }
+      ]
+    ]);
   });
 
   function resetPresetDemo() {
@@ -392,7 +390,7 @@ animation.addEventListener('finish', () => {
     const duration = parseInt(dom('#duration-input').val()) || 400;
     resetPresetDemo();
     dom('#preset-demo-box').css('opacity', '0');
-    dom('#preset-demo-box').fadeIn(duration);
+    dom('#preset-demo-box').withVisible().fadeIn(duration);
     dom('#preset-output').html(`<strong>Fade In animation!</strong> Duration: ${duration}ms. The element fades from transparent to opaque.`);
   });
 
@@ -407,7 +405,7 @@ animation.addEventListener('finish', () => {
     const duration = parseInt(dom('#duration-input').val()) || 400;
     resetPresetDemo();
     dom('#preset-demo-box').css({ transform: 'translateY(20px)', opacity: '0' });
-    dom('#preset-demo-box').slideUp(duration);
+    dom('#preset-demo-box').withVisible().slideUp(duration);
     dom('#preset-output').html(`<strong>Slide Up animation!</strong> Duration: ${duration}ms. The element slides up while fading in.`);
   });
 
@@ -415,7 +413,7 @@ animation.addEventListener('finish', () => {
     const duration = parseInt(dom('#duration-input').val()) || 400;
     resetPresetDemo();
     dom('#preset-demo-box').css({ transform: 'translateY(-20px)', opacity: '0' });
-    dom('#preset-demo-box').slideDown(duration);
+    dom('#preset-demo-box').withVisible().slideDown(duration);
     dom('#preset-output').html(`<strong>Slide Down animation!</strong> Duration: ${duration}ms. The element slides down while fading in.`);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.20",
+  "version": "1.6.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dmitrijkiltau/dom.js",
-      "version": "1.6.20",
+      "version": "1.6.25",
       "license": "MIT",
       "devDependencies": {
         "jsdom": "^26.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.23",
+  "version": "1.6.24",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.21",
+  "version": "1.6.22",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.20",
+  "version": "1.6.21",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.24",
+  "version": "1.6.25",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmitrijkiltau/dom.js",
-  "version": "1.6.22",
+  "version": "1.6.23",
   "description": "A lightweight, modular DOM manipulation library with chainable API, zero dependencies, and modern ES modules.",
   "type": "module",
   "main": "dist/index.cjs",
@@ -87,7 +87,7 @@
     "build:core": "tsup src/core.ts --format esm,cjs --dts --minify",
     "analyze": "node scripts/analyze-bundles.mjs",
     "dev": "tsup src/index.ts --format esm --dts --watch",
-    "test": "npm run build && node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/template-if.test.mjs && node ./tests/template-include.test.mjs && node ./tests/template-hydrate.test.mjs && node ./tests/template-html-unsafe.test.mjs && node ./tests/template-class-style.test.mjs && node ./tests/dom-manipulation.test.mjs && node ./tests/events-delegated.test.mjs && node ./tests/events-namespaces.test.mjs && node ./tests/trigger-init.test.mjs && node ./tests/qol-helpers.test.mjs",
+    "test": "npm run build && node ./tests/sanity.mjs && node ./tests/modular.mjs && node ./tests/template-each.test.mjs && node ./tests/template-if.test.mjs && node ./tests/template-include.test.mjs && node ./tests/template-hydrate.test.mjs && node ./tests/template-html-unsafe.test.mjs && node ./tests/template-class-style.test.mjs && node ./tests/dom-manipulation.test.mjs && node ./tests/events-delegated.test.mjs && node ./tests/events-namespaces.test.mjs && node ./tests/trigger-init.test.mjs && node ./tests/qol-helpers.test.mjs && node ./tests/in-view.test.mjs",
     "test:types": "tsc -p tests/tsconfig.types.json",
     "test:core": "node ./tests/sanity.mjs",
     "test:modular": "node ./tests/modular.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { animate, animations, installAnimationMethods, stagger, sequence } from 
 import { http } from './http';
 import { use } from './plugins';
 import { dom, fromHTML, create, on, once, off, ready } from './core-api';
-import { onIntersect, onResize, onMutation } from './observers';
+import { onIntersect, onResize, onMutation, inView } from './observers';
 import { scrollIntoView, scrollIntoViewIfNeeded } from './scroll';
 
 // ——— API bag (default export) ———
@@ -50,6 +50,7 @@ export interface Dom {
   onIntersect: typeof onIntersect;
   onResize: typeof onResize;
   onMutation: typeof onMutation;
+  inView: typeof inView;
   scrollIntoView: typeof scrollIntoView;
   scrollIntoViewIfNeeded: typeof scrollIntoViewIfNeeded;
   DOMCollection: typeof DOMCollection;
@@ -64,7 +65,7 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
   // Utilities
   debounce, throttle, nextTick, raf, rafThrottle,
   // Observers
-  onIntersect, onResize, onMutation,
+  onIntersect, onResize, onMutation, inView,
   // Scroll helpers
   scrollIntoView, scrollIntoViewIfNeeded,
   DOMCollection,
@@ -75,7 +76,7 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
 installAnimationMethods();
 
 // ——— Exports ———
-export { DOMCollection, renderTemplate, useTemplate, tpl, mountTemplate, hydrateTemplate, escapeHTML, unsafeHTML, isUnsafeHTML, serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid, animate, animations, stagger, sequence, http, use, debounce, throttle, nextTick, raf, rafThrottle, onIntersect, onResize, onMutation, scrollIntoView, scrollIntoViewIfNeeded };
+export { DOMCollection, renderTemplate, useTemplate, tpl, mountTemplate, hydrateTemplate, escapeHTML, unsafeHTML, isUnsafeHTML, serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid, animate, animations, stagger, sequence, http, use, debounce, throttle, nextTick, raf, rafThrottle, onIntersect, onResize, onMutation, inView, scrollIntoView, scrollIntoViewIfNeeded };
 export { setTemplateDevMode } from './template';
 export { dom, fromHTML, create, on, once, off, ready } from './core-api';
 export type Plugin = (api: Dom) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { debounce, throttle, nextTick, raf, rafThrottle } from './utils';
 import { DOMCollection } from './collection';
 import { renderTemplate, useTemplate, tpl, mountTemplate, escapeHTML, unsafeHTML, isUnsafeHTML, hydrateTemplate, setTemplateDevMode } from './template';
 import { serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid } from './forms';
-import { animate, animations, installAnimationMethods } from './motion';
+import { animate, animations, installAnimationMethods, stagger, sequence } from './motion';
 import { http } from './http';
 import { use } from './plugins';
 import { dom, fromHTML, create, on, once, off, ready } from './core-api';
@@ -40,6 +40,8 @@ export interface Dom {
   isValid: typeof isValid;
   animate: typeof animate;
   animations: typeof animations;
+  stagger: typeof stagger;
+  sequence: typeof sequence;
   debounce: typeof debounce;
   throttle: typeof throttle;
   nextTick: typeof nextTick;
@@ -58,7 +60,7 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
   dom, fromHTML, create, on, once, off, ready, http,
   renderTemplate, useTemplate, tpl, mountTemplate, hydrateTemplate, setTemplateDevMode, escapeHTML, unsafeHTML, isUnsafeHTML,
   serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid,
-  animate, animations,
+  animate, animations, stagger, sequence,
   // Utilities
   debounce, throttle, nextTick, raf, rafThrottle,
   // Observers
@@ -73,7 +75,7 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
 installAnimationMethods();
 
 // ——— Exports ———
-export { DOMCollection, renderTemplate, useTemplate, tpl, mountTemplate, hydrateTemplate, escapeHTML, unsafeHTML, isUnsafeHTML, serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid, animate, animations, http, use, debounce, throttle, nextTick, raf, rafThrottle, onIntersect, onResize, onMutation, scrollIntoView, scrollIntoViewIfNeeded };
+export { DOMCollection, renderTemplate, useTemplate, tpl, mountTemplate, hydrateTemplate, escapeHTML, unsafeHTML, isUnsafeHTML, serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid, animate, animations, stagger, sequence, http, use, debounce, throttle, nextTick, raf, rafThrottle, onIntersect, onResize, onMutation, scrollIntoView, scrollIntoViewIfNeeded };
 export { setTemplateDevMode } from './template';
 export { dom, fromHTML, create, on, once, off, ready } from './core-api';
 export type Plugin = (api: Dom) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { http } from './http';
 import { use } from './plugins';
 import { dom, fromHTML, create, on, once, off, ready } from './core-api';
 import { onIntersect, onResize, onMutation, inView } from './observers';
-import { scrollIntoView, scrollIntoViewIfNeeded } from './scroll';
+import { scrollIntoView, scrollIntoViewIfNeeded, lockScroll, unlockScroll } from './scroll';
 
 // ——— API bag (default export) ———
 export interface Dom {
@@ -53,6 +53,8 @@ export interface Dom {
   inView: typeof inView;
   scrollIntoView: typeof scrollIntoView;
   scrollIntoViewIfNeeded: typeof scrollIntoViewIfNeeded;
+  lockScroll: typeof lockScroll;
+  unlockScroll: typeof unlockScroll;
   DOMCollection: typeof DOMCollection;
   use: (plugin: Plugin) => void;
 }
@@ -67,7 +69,7 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
   // Observers
   onIntersect, onResize, onMutation, inView,
   // Scroll helpers
-  scrollIntoView, scrollIntoViewIfNeeded,
+  scrollIntoView, scrollIntoViewIfNeeded, lockScroll, unlockScroll,
   DOMCollection,
   use: (plugin: Plugin) => use(plugin, api as any)
 }) as Dom;
@@ -76,7 +78,7 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
 installAnimationMethods();
 
 // ——— Exports ———
-export { DOMCollection, renderTemplate, useTemplate, tpl, mountTemplate, hydrateTemplate, escapeHTML, unsafeHTML, isUnsafeHTML, serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid, animate, animations, stagger, sequence, http, use, debounce, throttle, nextTick, raf, rafThrottle, onIntersect, onResize, onMutation, inView, scrollIntoView, scrollIntoViewIfNeeded };
+export { DOMCollection, renderTemplate, useTemplate, tpl, mountTemplate, hydrateTemplate, escapeHTML, unsafeHTML, isUnsafeHTML, serializeForm, toQueryString, onSubmit, toFormData, setForm, resetForm, validateForm, isValid, animate, animations, stagger, sequence, http, use, debounce, throttle, nextTick, raf, rafThrottle, onIntersect, onResize, onMutation, inView, scrollIntoView, scrollIntoViewIfNeeded, lockScroll, unlockScroll };
 export { setTemplateDevMode } from './template';
 export { dom, fromHTML, create, on, once, off, ready } from './core-api';
 export type Plugin = (api: Dom) => void;

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,48 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
   DOMCollection
 });
 
+// ——— Install SSR-safe stubs on DOMCollection ———
+// These mirror motion/scroll collection methods so code can call them on server.
+// Motion methods resolve immediately with the original collection; scroll methods no-op.
+(() => {
+  const proto: any = (DOMCollection as any).prototype;
+
+  // Motion: Promise-returning methods resolve immediately
+  const resolved = function <T>(this: T): Promise<T> { return Promise.resolve(this); };
+
+  proto.animate = function () { return resolved.call(this); };
+  proto.sequence = function () { return resolved.call(this); };
+  proto.stagger = function () { return resolved.call(this); };
+  proto.fadeIn = function () { return resolved.call(this); };
+  proto.fadeOut = function () { return resolved.call(this); };
+  proto.fadeToggle = function () { return resolved.call(this); };
+  proto.slideUp = function () { return resolved.call(this); };
+  proto.slideDown = function () { return resolved.call(this); };
+  proto.slideToggle = function () { return resolved.call(this); };
+  proto.pulse = function () { return resolved.call(this); };
+  proto.shake = function () { return resolved.call(this); };
+
+  // Visibility preset helper
+  proto.withVisible = function () {
+    const base = this;
+    return {
+      animate: () => Promise.resolve(base),
+      sequence: () => Promise.resolve(base),
+      fadeIn: () => Promise.resolve(base),
+      slideDown: () => Promise.resolve(base)
+    };
+  };
+
+  // Motion control: no-ops returning the collection
+  proto.pause = function () { return this; };
+  proto.resume = function () { return this; };
+  proto.cancel = function () { return this; };
+  proto.stop = function () { return this; };
+
+  // Scroll collection helpers: no-ops returning the collection
+  proto.scrollIntoView = function () { return this; };
+  proto.scrollIntoViewIfNeeded = function () { return this; };
+})();
+
 export type ServerDom = typeof api;
 export default api;
-

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,3 +88,35 @@ const api = Object.assign(function core<T extends Element = Element>(input?: Sel
 
 export type ServerDom = typeof api;
 export default api;
+
+// ——— Type augmentations (so server entry has typed stubs) ———
+declare module './collection' {
+  interface DOMCollection<T extends Element = Element> {
+    // Motion (promise-returning)
+    animate(keyframes: Keyframe[] | PropertyIndexedKeyframes, options?: KeyframeAnimationOptions): Promise<this>;
+    sequence(steps: Array<[Keyframe[] | PropertyIndexedKeyframes, KeyframeAnimationOptions] | ((el: HTMLElement, idx: number) => [Keyframe[] | PropertyIndexedKeyframes, KeyframeAnimationOptions]) | number>): Promise<this>;
+    stagger(stepMs: number, fn: (el: HTMLElement, idx: number) => any): Promise<this>;
+    fadeIn(duration?: number): Promise<this>;
+    fadeOut(duration?: number): Promise<this>;
+    fadeToggle(duration?: number): Promise<this>;
+    slideUp(duration?: number): Promise<this>;
+    slideDown(duration?: number): Promise<this>;
+    slideToggle(duration?: number): Promise<this>;
+    pulse(duration?: number): Promise<this>;
+    shake(duration?: number): Promise<this>;
+    withVisible(display?: string): {
+      animate: (keyframes: Keyframe[] | PropertyIndexedKeyframes, options?: KeyframeAnimationOptions) => Promise<DOMCollection<T>>;
+      sequence: (steps: Array<[Keyframe[] | PropertyIndexedKeyframes, KeyframeAnimationOptions] | ((el: HTMLElement, idx: number) => [Keyframe[] | PropertyIndexedKeyframes, KeyframeAnimationOptions]) | number>) => Promise<DOMCollection<T>>;
+      fadeIn: (duration?: number) => Promise<DOMCollection<T>>;
+      slideDown: (duration?: number) => Promise<DOMCollection<T>>;
+    };
+    // Motion control
+    pause(): this;
+    resume(): this;
+    cancel(): this;
+    stop(jumpToEnd?: boolean): this;
+    // Scroll
+    scrollIntoView(options?: import('./scroll').ScrollOptions): this;
+    scrollIntoViewIfNeeded(options?: Omit<import('./scroll').ScrollOptions, 'ifNeeded'>): this;
+  }
+}

--- a/tests/in-view.test.mjs
+++ b/tests/in-view.test.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { JSDOM } from 'jsdom';
+
+console.log('\n🧪 Testing inView() helper...');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    passed++;
+  } catch (error) {
+    console.error(`❌ ${name}: ${error.message}`);
+    failed++;
+  }
+}
+
+// Setup DOM
+const dom = new JSDOM('<!doctype html><html><body><div id="a"></div><div id="b"></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.Element = dom.window.Element;
+global.HTMLElement = dom.window.HTMLElement;
+
+// Minimal fake IntersectionObserver
+class FakeIntersectionObserver {
+  constructor(cb, options) {
+    this._cb = cb;
+    this._options = options || {};
+    this._observed = new Set();
+    global.__lastIO = this;
+  }
+  observe(el) { this._observed.add(el); }
+  unobserve(el) { this._observed.delete(el); }
+  disconnect() { this._observed.clear(); }
+  trigger(entries) {
+    const filtered = entries.filter(e => this._observed.has(e.target));
+    if (filtered.length) this._cb(filtered);
+  }
+}
+
+global.window.IntersectionObserver = FakeIntersectionObserver;
+global.IntersectionObserver = FakeIntersectionObserver;
+
+const api = (await import('../dist/index.js')).default;
+
+test('enter/leave fire around threshold', () => {
+  const a = document.getElementById('a');
+  const b = document.getElementById('b');
+
+  const iv = api.inView('#a, #b', { threshold: 0.5 });
+  let enters = 0, leaves = 0;
+  iv.enter((el, entry) => { enters++; }).leave((el, entry) => { leaves++; });
+
+  const io = global.__lastIO;
+  io.trigger([
+    { target: a, isIntersecting: true, intersectionRatio: 0.6 },
+    { target: b, isIntersecting: false, intersectionRatio: 0.0 }
+  ]);
+  if (enters !== 1 || leaves !== 0) throw new Error('enter should fire for #a only');
+
+  io.trigger([
+    { target: a, isIntersecting: true, intersectionRatio: 0.4 },
+    { target: b, isIntersecting: true, intersectionRatio: 0.7 }
+  ]);
+  if (enters !== 2) throw new Error('enter should fire for #b');
+  if (leaves !== 1) throw new Error('leave should fire for #a');
+
+  iv.stop();
+});
+
+test('once:true unobserves after first enter per element', () => {
+  const a = document.getElementById('a');
+
+  const iv = api.inView('#a', { threshold: 0.25, once: true });
+  let enters = 0, leaves = 0;
+  iv.enter(() => { enters++; }).leave(() => { leaves++; });
+
+  const io = global.__lastIO;
+  io.trigger([{ target: a, isIntersecting: true, intersectionRatio: 0.3 }]);
+  if (enters !== 1) throw new Error('enter should fire once');
+
+  io.trigger([{ target: a, isIntersecting: true, intersectionRatio: 0.1 }]);
+  if (leaves !== 0) throw new Error('leave should not fire after unobserve');
+
+  iv.stop();
+});
+
+console.log(`\n📊 inView: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);
+


### PR DESCRIPTION
This pull request introduces several new animation and observer utilities to the `dom.js` library, updates documentation and demos to showcase these features, and improves navigation logic in the docs site. The main changes include adding `sequence`, `stagger`, and `withVisible` animation helpers, a new `inView` observer utility, scroll locking APIs, and updating the documentation and demos to reflect these additions. Navigation in the documentation is now more robust and consistently ordered.

**Animation & Motion Utilities:**
* Added new animation composition helpers: `sequence` (for chaining multiple animations), `stagger` (for animating collections with delays), and `withVisible` (ensures elements are visible before animating). These are now available on `DOMCollection` and documented in `REFERENCE.md` and `README.md`. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L6-R11) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R43-R44) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L277-R335) [[4]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL157-R166) [[5]](diffhunk://#diff-7daae1ca2f18e4790767e1258a91d4c9984e2ee845f3bbfcced112f7c784acd8L342-R378)
* Updated animation demos to use `.sequence()` and `.withVisible()` for more concise, readable examples. [[1]](diffhunk://#diff-7daae1ca2f18e4790767e1258a91d4c9984e2ee845f3bbfcced112f7c784acd8L342-R378) [[2]](diffhunk://#diff-7daae1ca2f18e4790767e1258a91d4c9984e2ee845f3bbfcced112f7c784acd8L395-R393) [[3]](diffhunk://#diff-7daae1ca2f18e4790767e1258a91d4c9984e2ee845f3bbfcced112f7c784acd8L410-R416)

**Observers & Scroll Utilities:**
* Introduced the `inView` observer utility for subscribing to element visibility changes, and added `lockScroll`/`unlockScroll` for page or container scroll locking. These are documented and exposed in the main API. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L6-R11) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R53-R57) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R97) [[4]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL157-R166)
* Updated documentation to describe the new observer and scroll APIs, including usage examples. [[1]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL157-R166) [[2]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL30-R33)

**Documentation & Navigation:**
* Navigation data in the docs site is now derived from section definitions for consistent ordering.
* Improved scroll navigation: smooth scrolling uses the new utility, and scroll spy now robustly updates the URL hash based on scroll position rather than intersection observer, improving accuracy and consistency. [[1]](diffhunk://#diff-d4d7570c3dd131aeac93f0592b501aad1193523f16032216508ddb23532734f3L1-R1) [[2]](diffhunk://#diff-d4d7570c3dd131aeac93f0592b501aad1193523f16032216508ddb23532734f3L56-R82) [[3]](diffhunk://#diff-d4d7570c3dd131aeac93f0592b501aad1193523f16032216508ddb23532734f3L189-R178) [[4]](diffhunk://#diff-d4d7570c3dd131aeac93f0592b501aad1193523f16032216508ddb23532734f3L201-L202)

**Package Updates:**
* Bumped versions in `package.json` and `docs/package.json` to reflect new features and updates. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-adfa337ce44dc2902621da20152a048dac41878cf3716dfc4cc56d03aa212a56L3-R3)
* Added a new test for `inView` to the test script.

**API Documentation:**
* Updated module summaries and API tables in `REFERENCE.md` to reflect new methods and helpers. [[1]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL14-R17) [[2]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL30-R33) [[3]](diffhunk://#diff-6269a4217141bc6fd747b87032c8f248c977cfd8b2f0d0d7d1ba04af62ba229aL157-R166)